### PR TITLE
Fix description in GetVideoDetails

### DIFF
--- a/index.js
+++ b/index.js
@@ -270,10 +270,7 @@ const GetVideoDetails = async (videoId) => {
         ? firstContent.viewCount.videoViewCountRenderer.isLive
         : false,
       channel: secondContent.owner.videoOwnerRenderer.title.runs[0].text,
-      description: secondContent.description.runs
-        .map((x) => x.text)
-        .join()
-        .toString(),
+      description: secondContent.attributedDescription.content,
       suggestion: result.secondaryResults.secondaryResults.results
         .filter((y) => y.hasOwnProperty("compactVideoRenderer"))
         .map((x) => compactVideoRenderer(x)),


### PR DESCRIPTION
I think the YouTube internal api has changed and broke the GetVideoDetails method. Here is an updated version.